### PR TITLE
Fix proxy method wrapper self reference

### DIFF
--- a/slowstore/__init__.py
+++ b/slowstore/__init__.py
@@ -87,7 +87,7 @@ class ModelProxy(Generic[T]):
                 func = attr.__func__
 
                 def wrapper(*args, **kwargs):
-                    return func(self, *args, **kwargs)
+                    return func(self.model, *args, **kwargs)
 
                 wrapper.__name__ = func_name
                 return wrapper

--- a/tests/test_slowstore.py
+++ b/tests/test_slowstore.py
@@ -110,3 +110,10 @@ def test_save_changes_on_file(store: Slowstore[SampleModel]):
 
     assert len(proxy.__changes__) == 1
     assert model2.name == "tito"
+
+
+def test_model_dump(store: Slowstore[SampleModel]):
+    store.clear()
+    key = "test"
+    model = store.upsert(key, SampleModel(name="test1"))
+    assert model.model_dump_json() == "{\"name\":\"test1\",\"age\":0}"


### PR DESCRIPTION
There was a mistake where the wrapper method in getattr was referencing the proxy instead of the model itself.